### PR TITLE
fixed a memory leak in OpenCdm::DecryptToMediaDecoderBuffer()

### DIFF
--- a/src/browser/chrome/open_cdm.cc
+++ b/src/browser/chrome/open_cdm.cc
@@ -676,6 +676,8 @@ cdm::Status OpenCdm::DecryptToMediaDecoderBuffer(
   CopySubsamples(subsamples, kDstContainsClearBytes, out,
                  output->writable_data());
 
+  delete[] out;
+
   *decrypted_buffer = output;
   if (dr.platform_response == PLATFORM_CALL_SUCCESS) {
     return cdm::kSuccess;


### PR DESCRIPTION
OpenCdm::DecryptToMediaDecoderBuffer() function was not freeing a buffer it used temporarily. We were seeing system performance degrading after several minutes of playback due to memory leak.